### PR TITLE
インターフェース/パッケージの整理

### DIFF
--- a/dummy/find.go
+++ b/dummy/find.go
@@ -16,8 +16,6 @@ package dummy
 
 import (
 	"context"
-
-	"github.com/sacloud/services"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
@@ -32,8 +30,6 @@ type FindRequest struct {
 	Field1 string `validate:"required"`
 	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
 }
-
-var _ services.Parameter = (*FindRequest)(nil)
 
 func (req *FindRequest) KeyFieldNames() []string {
 	return []string{"Field1"}

--- a/dummy/service.go
+++ b/dummy/service.go
@@ -20,9 +20,16 @@ import (
 	"github.com/sacloud/services/validate"
 )
 
+var _ services.Service = (*Service)(nil)
+
 type Service struct{}
 
-var _ services.Service = (*Service)(nil)
+func (s *Service) Info() *services.Info {
+	return &services.Info{
+		Description: "Description for Dummy service",
+		ParentKeys:  nil,
+	}
+}
 
 func (s *Service) Operations() []services.SupportedOperation {
 	return []services.SupportedOperation{
@@ -42,7 +49,7 @@ func (s *Service) Config() *services.Config {
 	}
 }
 
-func (s *Service) Validate(p services.Parameter) error {
+func (s *Service) Validate(p interface{}) error {
 	return validate.New(s).Struct(p)
 }
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/meta"
+	"github.com/sacloud/services/validate"
+)
+
+// ParameterMeta 指定のfuncのパラメータが持つ各フィールドのメタデータを取得
+func ParameterMeta(service services.Service, funcName string) ([]meta.StructField, error) {
+	parser := metaParser(service)
+	instance, err := NewParameter(service, funcName)
+	if err != nil {
+		return nil, err
+	}
+	return parser.Parse(instance)
+}
+
+// NewParameter 指定のfuncのパラメータを新規作成&初期化して返す
+func NewParameter(service services.Service, funcName string) (interface{}, error) {
+	method, found := reflect.TypeOf(service).MethodByName(funcName)
+	if !found {
+		return nil, fmt.Errorf("method %q not found", funcName)
+	}
+	instance := reflect.New(method.Type.In(1).Elem()).Interface()
+	if v, ok := instance.(services.ParameterInitializer); ok {
+		v.Initialize()
+	}
+	return instance, nil
+}
+
+// ValidateStruct serviceのコンフィグを反映したバリデーターを用いたバリデーション
+func ValidateStruct(service services.Service, parameter interface{}) error {
+	if err := validate.New(service).Struct(parameter); err != nil {
+		return err
+	}
+	if p, ok := parameter.(services.ParameterValidator); ok {
+		return p.Validate()
+	}
+	return nil
+}
+
+func metaParser(service services.Service) *meta.Parser {
+	config := service.Config()
+	tagName := config.MetaTagName
+	if tagName == "" {
+		tagName = meta.DefaultTagName
+	}
+	return &meta.Parser{
+		Config: &meta.ParserConfig{
+			TagName: tagName,
+			Options: config.OptionDefs,
+		},
+	}
+}

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -12,25 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package services_test
+package helper
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/sacloud/services"
 	"github.com/sacloud/services/dummy"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParameterMeta(t *testing.T) {
-	fields, err := services.ParameterMeta(dummy.New(), "Find")
-	t.Log(fields)
-
+	fields, err := ParameterMeta(dummy.New(), "Find")
 	require.NoError(t, err)
+
+	for i, field := range fields {
+		fmt.Printf("Fields[%d]:\n", i)
+		fmt.Printf("\tStructField: %#+v\n", field.StructField)
+		fmt.Printf("\tTag: %#+v\n", field.Tag)
+		fmt.Printf("\tLongDescription: %#+v\n", field.Tag.LongDescription())
+		fmt.Printf("\tAliasesString: %#+v\n", field.Tag.AliasesString())
+		fmt.Printf("\tOptionsString: %#+v\n", field.Tag.OptionsString())
+	}
 }
 
 func TestNewParameter(t *testing.T) {
-	parameter, err := services.NewParameter(dummy.New(), "Find")
+	parameter, err := NewParameter(dummy.New(), "Find")
 	require.NoError(t, err)
 	require.NotNil(t, parameter)
 
@@ -44,7 +51,7 @@ func TestNewParameter(t *testing.T) {
 func TestValidateParameter(t *testing.T) {
 	tests := []struct {
 		name      string
-		parameter services.Parameter
+		parameter interface{}
 		wantErr   bool
 	}{
 		{
@@ -75,7 +82,7 @@ func TestValidateParameter(t *testing.T) {
 	for _, tt := range tests {
 		service := dummy.New()
 		t.Run(tt.name, func(t *testing.T) {
-			if err := services.ValidateParameter(service, tt.parameter); (err != nil) != tt.wantErr {
+			if err := ValidateStruct(service, tt.parameter); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateParameter() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/operations.go
+++ b/operations.go
@@ -19,12 +19,12 @@ type Operations int
 
 const (
 	OperationsUnknown Operations = iota
-	OperationsCreate
-	OperationsRead
-	OperationsUpdate
-	OperationsDelete
-	OperationsList
-	OperationsAction
+	OperationsCreate             // Id:不要	/ 戻り値:単体
+	OperationsRead               // Id:要 	/ 戻り値:単体
+	OperationsUpdate             // Id:要 	/ 戻り値:単体
+	OperationsDelete             // Id:要 	/ 戻り値:なし
+	OperationsList               // Id:不要	/ 戻り値: スライス
+	OperationsAction             // Id:要 	/ 戻り値: なし
 )
 
 func (o Operations) String() string {

--- a/parameter.go
+++ b/parameter.go
@@ -14,71 +14,13 @@
 
 package services
 
-import (
-	"fmt"
-	"reflect"
-
-	"github.com/sacloud/services/meta"
-)
-
-// Parameter 各パラメータが実装すべきインターフェース
-type Parameter interface {
-	// Initialize パラメータの初期値投入
+// ParameterInitializer パラメータの初期化時に特別な処理を行いたい場合に実装すべきインターフェース
+type ParameterInitializer interface {
+	// Initialize パラメータの初期カスタマイズ
 	Initialize()
-
-	// KeyFieldNames キーとなる項目のフィールド名リスト
-	KeyFieldNames() []string
 }
 
 // ParameterValidator パラメータが独自のバリデーションを実装する場合に実装すべきインターフェース
 type ParameterValidator interface {
 	Validate() error
-}
-
-// ParameterMeta 指定のfuncのパラメータが持つ各フィールドのメタデータを取得
-func ParameterMeta(service Service, funcName string) ([]meta.StructField, error) {
-	parser := metaParser(service)
-	instance, err := NewParameter(service, funcName)
-	if err != nil {
-		return nil, err
-	}
-	return parser.Parse(instance)
-}
-
-// NewParameter 指定のfuncのパラメータを新規作成&初期化して返す
-func NewParameter(service Service, funcName string) (interface{}, error) {
-	method, found := reflect.TypeOf(service).MethodByName(funcName)
-	if !found {
-		return nil, fmt.Errorf("method %q not found", funcName)
-	}
-	instance := reflect.New(method.Type.In(1).Elem()).Interface()
-	if v, ok := instance.(Parameter); ok {
-		v.Initialize()
-	}
-	return instance, nil
-}
-
-// ValidateParameter serviceのコンフィグを反映したバリデーターを用いたバリデーション
-func ValidateParameter(service Service, parameter Parameter) error {
-	if err := service.Validate(parameter); err != nil {
-		return err
-	}
-	if p, ok := parameter.(ParameterValidator); ok {
-		return p.Validate()
-	}
-	return nil
-}
-
-func metaParser(service Service) *meta.Parser {
-	config := service.Config()
-	tagName := config.MetaTagName
-	if tagName == "" {
-		tagName = meta.DefaultTagName
-	}
-	return &meta.Parser{
-		Config: &meta.ParserConfig{
-			TagName: tagName,
-			Options: config.OptionDefs,
-		},
-	}
 }

--- a/service.go
+++ b/service.go
@@ -16,19 +16,33 @@ package services
 
 // SupportedOperation サービスが提供する操作のメタデータ
 type SupportedOperation struct {
-	Name          string
+	// 操作(メソッド)の名前
+	Name string
+
+	// 操作種別、種別によりIdが必要/不要が決定される
 	OperationType Operations
 }
 
 // Service 各サービスが実装すべきインターフェース
 type Service interface {
+	// Info サービスについての情報を返す
+	Info() *Info
+
 	// Operations サポートしている操作のメタデータ一覧
 	// この要素それぞれに対しxxxWithContext()が存在することが期待される
 	Operations() []SupportedOperation
 
 	// Config コンフィグ
 	Config() *Config
+}
 
-	// Validate .
-	Validate(p Parameter) error
+// Info サービスについての情報
+type Info struct {
+	// サービスの説明
+	Description string
+
+	// 親リソースを特定するために必要なフィールドの名前
+	//
+	// 例えばサーバの配下のリソースであれば"ServerId"などが指定される
+	ParentKeys []string
 }


### PR DESCRIPTION
closes #6 

サンプル実装からのフィードバックを受けインターフェース/パッケージを整理

- services.Parameterインターフェースの廃止
- services.Serviceにサービス自体の情報を取得するためのfuncを追加
- servicesのインターフェースを使うfuncをhelperパッケージへ移動