### PR TITLE
サービスメタデータにサービス名称を追加

### DIFF
--- a/dummy/service.go
+++ b/dummy/service.go
@@ -26,6 +26,7 @@ type Service struct{}
 
 func (s *Service) Info() *services.Info {
 	return &services.Info{
+		Name:        "dummy",
 		Description: "Description for Dummy service",
 		ParentKeys:  nil,
 	}

--- a/service.go
+++ b/service.go
@@ -38,6 +38,9 @@ type Service interface {
 
 // Info サービスについての情報
 type Info struct {
+	// サービスの名前
+	Name string
+
 	// サービスの説明
 	Description string
 


### PR DESCRIPTION
サービスのパッケージ名がサービス名を兼ねる想定だったが、両者が異なるケースがあるためメタデータで名称を持つ形とする。