### PR TITLE
Dispatcherの導入

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -1,0 +1,115 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/sacloud/services"
+	"github.com/sacloud/services/helper"
+)
+
+var registry = map[string]services.Service{}
+
+func Register(platformName string, service services.Service) {
+	if platformName == "" {
+		panic("platformName is required")
+	}
+	arguments := []string{platformName, service.Info().FullName()}
+	registry[key(arguments)] = service
+}
+
+func Dispatch(arguments []string, parameter interface{}) (interface{}, error) {
+	return DispatchWithContext(context.Background(), arguments, parameter)
+}
+
+func DispatchWithContext(ctx context.Context, arguments []string, parameter interface{}) (interface{}, error) {
+	if len(arguments) < 2 {
+		panic("invalid arguments")
+	}
+	keys, operation := arguments[:len(arguments)-1], arguments[len(arguments)-1]
+	service, ok := registry[key(keys)]
+	if !ok {
+		return nil, fmt.Errorf("service %s not found", key(keys))
+	}
+	for _, op := range service.Operations() {
+		if op.EqualsByName(operation) {
+			return dispatch(ctx, service, op, parameter)
+		}
+	}
+	return nil, fmt.Errorf("operation %s#%s not found", key(keys), operation)
+}
+
+func serviceParameter(service services.Service, op services.SupportedOperation, parameter interface{}) (interface{}, error) {
+	if parameter == nil {
+		parameter = map[string]interface{}{}
+	}
+
+	param, err := helper.NewParameter(service, op.Name)
+	if err != nil {
+		return nil, err
+	}
+	data, err := json.Marshal(parameter)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(data, param); err != nil {
+		return nil, err
+	}
+	return param, nil
+}
+
+func dispatch(ctx context.Context, service services.Service, op services.SupportedOperation, parameter interface{}) (interface{}, error) {
+	param, err := serviceParameter(service, op, parameter)
+	if err != nil {
+		return nil, err
+	}
+
+	method := reflect.ValueOf(service).MethodByName(op.WithContextFuncName())
+	results := method.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(param)}) // xxxWithContextはctx+reqの2つだけを受け取るはず
+
+	switch op.OperationType {
+	case services.OperationsCreate, services.OperationsRead, services.OperationsUpdate, services.OperationsList:
+		if len(results) != 2 {
+			return nil, fmt.Errorf("invalid results: want 2 results, but got %d: %+v", len(results), results)
+		}
+		value := results[0].Interface()
+		var err error
+		if e, ok := results[1].Interface().(error); ok {
+			err = e
+		}
+		return value, err
+	case services.OperationsAction, services.OperationsDelete:
+		if len(results) != 1 {
+			return nil, fmt.Errorf("invalid results: want 1 results, but got %d: %+v", len(results), results)
+		}
+
+		var err error
+		if e, ok := results[0].Interface().(error); ok {
+			err = e
+		}
+		return nil, err
+	default:
+		panic(fmt.Sprintf("unknown operation type: %s", op.OperationType))
+	}
+}
+
+func key(arguments []string) string {
+	return strings.Join(arguments, "/")
+}

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -1,0 +1,154 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"testing"
+
+	"github.com/sacloud/services/dummy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDispatch(t *testing.T) {
+	type args struct {
+		arguments []string
+		parameter interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "invalid platform",
+			args: args{
+				arguments: []string{"invalid", "dummy", "dummy"},
+				parameter: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "operation not found",
+			args: args{
+				arguments: []string{"dummy", "dummy", "not-found"},
+				parameter: map[string]interface{}{
+					"Field1": "required",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "with results operation",
+			args: args{
+				arguments: []string{"dummy", "dummy", "find"},
+				parameter: map[string]interface{}{
+					"Field1": "required",
+				},
+			},
+			want: []*dummy.FindResult{
+				{Dummy: "result1"},
+				{Dummy: "result2"},
+				{Dummy: "result3"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "with result operation",
+			args: args{
+				arguments: []string{"dummy", "dummy", "read"},
+				parameter: map[string]interface{}{},
+			},
+			want:    &dummy.ReadResult{Dummy: "result"},
+			wantErr: false,
+		},
+		{
+			name: "with error from operation",
+			args: args{
+				arguments: []string{"dummy", "dummy", "error-read"},
+				parameter: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "action without error",
+			args: args{
+				arguments: []string{"dummy", "dummy", "action"},
+				parameter: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "action with error",
+			args: args{
+				arguments: []string{"dummy", "dummy", "error-action"},
+				parameter: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "parameter",
+			args: args{
+				arguments: []string{"dummy", "dummy", "echo"},
+				parameter: map[string]interface{}{
+					"Field1": "value1",
+					"Field2": "value2",
+				},
+			},
+			want: &dummy.EchoRequest{
+				Field1: "value1",
+				Field2: "value2",
+			},
+			wantErr: false,
+		},
+	}
+
+	// 準備
+	Register("dummy", dummy.New())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Dispatch(tt.args.arguments, tt.args.parameter)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Dispatch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err == nil {
+				require.EqualValues(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDispatch_panic(t *testing.T) {
+	Register("dummy", dummy.New())
+
+	defer func() {
+		panicMessage := recover()
+		require.Equal(t, "invalid arguments", panicMessage)
+	}()
+	Dispatch([]string{}, nil) // nolint
+}
+
+func TestRegister_panic(t *testing.T) {
+	defer func() {
+		panicMessage := recover()
+		require.Equal(t, "platformName is required", panicMessage)
+	}()
+	Register("", dummy.New())
+}

--- a/dispatcher/example_test.go
+++ b/dispatcher/example_test.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher_test
+
+import (
+	"fmt"
+
+	"github.com/sacloud/services/dispatcher"
+	"github.com/sacloud/services/dummy"
+)
+
+func Example() {
+	// サービスの登録
+	dispatcher.Register("my-platform", dummy.New())
+
+	// サービスの呼び出し(プラットフォーム名 + 対象リソース名 + 操作, パラメータを渡す)
+	arguments := []string{"my-platform", "dummy", "read"}
+	parameter := map[string]interface{}{"Param1": "example"}
+
+	result, err := dispatcher.Dispatch(arguments, parameter)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(result.(*dummy.ReadResult).Dummy)
+	// output: result
+}

--- a/dummy/action.go
+++ b/dummy/action.go
@@ -18,29 +18,13 @@ import (
 	"context"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
-	return s.FindWithContext(context.Background(), req)
+func (s *Service) Action(req *ActionRequest) error {
+	return s.ActionWithContext(context.Background(), req)
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*FindResult, error) {
-	return []*FindResult{
-		{Dummy: "result1"},
-		{Dummy: "result2"},
-		{Dummy: "result3"},
-	}, nil
+func (s *Service) ActionWithContext(ctx context.Context, req *ActionRequest) error {
+	return nil
 }
 
-type FindRequest struct {
-	Field1 string `validate:"required"`
-	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
-}
-
-func (req *FindRequest) Initialize() {
-	// 初期値はここで設定する
-	req.Field1 = "init"
-	req.Field2 = "init"
-}
-
-type FindResult struct {
-	Dummy string
+type ActionRequest struct {
 }

--- a/dummy/echo.go
+++ b/dummy/echo.go
@@ -18,29 +18,15 @@ import (
 	"context"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
-	return s.FindWithContext(context.Background(), req)
+func (s *Service) Echo(req *EchoRequest) (*EchoRequest, error) {
+	return s.EchoWithContext(context.Background(), req)
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*FindResult, error) {
-	return []*FindResult{
-		{Dummy: "result1"},
-		{Dummy: "result2"},
-		{Dummy: "result3"},
-	}, nil
+func (s *Service) EchoWithContext(ctx context.Context, req *EchoRequest) (*EchoRequest, error) {
+	return req, nil
 }
 
-type FindRequest struct {
-	Field1 string `validate:"required"`
-	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
-}
-
-func (req *FindRequest) Initialize() {
-	// 初期値はここで設定する
-	req.Field1 = "init"
-	req.Field2 = "init"
-}
-
-type FindResult struct {
-	Dummy string
+type EchoRequest struct {
+	Field1 string
+	Field2 string
 }

--- a/dummy/error_action.go
+++ b/dummy/error_action.go
@@ -16,31 +16,16 @@ package dummy
 
 import (
 	"context"
+	"fmt"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
-	return s.FindWithContext(context.Background(), req)
+func (s *Service) ErrorAction(req *ErrorActionRequest) error {
+	return s.ErrorActionWithContext(context.Background(), req)
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*FindResult, error) {
-	return []*FindResult{
-		{Dummy: "result1"},
-		{Dummy: "result2"},
-		{Dummy: "result3"},
-	}, nil
+func (s *Service) ErrorActionWithContext(ctx context.Context, req *ErrorActionRequest) error {
+	return fmt.Errorf("dummy")
 }
 
-type FindRequest struct {
-	Field1 string `validate:"required"`
-	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
-}
-
-func (req *FindRequest) Initialize() {
-	// 初期値はここで設定する
-	req.Field1 = "init"
-	req.Field2 = "init"
-}
-
-type FindResult struct {
-	Dummy string
+type ErrorActionRequest struct {
 }

--- a/dummy/error_read.go
+++ b/dummy/error_read.go
@@ -16,31 +16,19 @@ package dummy
 
 import (
 	"context"
+	"fmt"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
-	return s.FindWithContext(context.Background(), req)
+func (s *Service) ErrorRead(req *ErrorReadRequest) (*ErrorReadResult, error) {
+	return s.ErrorReadWithContext(context.Background(), req)
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*FindResult, error) {
-	return []*FindResult{
-		{Dummy: "result1"},
-		{Dummy: "result2"},
-		{Dummy: "result3"},
-	}, nil
+func (s *Service) ErrorReadWithContext(ctx context.Context, req *ErrorReadRequest) (*ErrorReadResult, error) {
+	return nil, fmt.Errorf("dummy")
 }
 
-type FindRequest struct {
-	Field1 string `validate:"required"`
-	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
+type ErrorReadRequest struct {
 }
 
-func (req *FindRequest) Initialize() {
-	// 初期値はここで設定する
-	req.Field1 = "init"
-	req.Field2 = "init"
-}
-
-type FindResult struct {
-	Dummy string
+type ErrorReadResult struct {
 }

--- a/dummy/read.go
+++ b/dummy/read.go
@@ -18,29 +18,17 @@ import (
 	"context"
 )
 
-func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
-	return s.FindWithContext(context.Background(), req)
+func (s *Service) Read(req *ReadRequest) (*ReadResult, error) {
+	return s.ReadWithContext(context.Background(), req)
 }
 
-func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*FindResult, error) {
-	return []*FindResult{
-		{Dummy: "result1"},
-		{Dummy: "result2"},
-		{Dummy: "result3"},
-	}, nil
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*ReadResult, error) {
+	return &ReadResult{Dummy: "result"}, nil
 }
 
-type FindRequest struct {
-	Field1 string `validate:"required"`
-	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
+type ReadRequest struct {
 }
 
-func (req *FindRequest) Initialize() {
-	// 初期値はここで設定する
-	req.Field1 = "init"
-	req.Field2 = "init"
-}
-
-type FindResult struct {
+type ReadResult struct {
 	Dummy string
 }

--- a/dummy/service.go
+++ b/dummy/service.go
@@ -35,8 +35,28 @@ func (s *Service) Info() *services.Info {
 func (s *Service) Operations() []services.SupportedOperation {
 	return []services.SupportedOperation{
 		{
-			Name:          "Find",
+			Name:          "find",
 			OperationType: services.OperationsList,
+		},
+		{
+			Name:          "read",
+			OperationType: services.OperationsRead,
+		},
+		{
+			Name:          "error-read",
+			OperationType: services.OperationsRead,
+		},
+		{
+			Name:          "echo",
+			OperationType: services.OperationsRead,
+		},
+		{
+			Name:          "action",
+			OperationType: services.OperationsAction,
+		},
+		{
+			Name:          "error-action",
+			OperationType: services.OperationsAction,
 		},
 	}
 }

--- a/dummy/service.go
+++ b/dummy/service.go
@@ -26,9 +26,9 @@ type Service struct{}
 
 func (s *Service) Info() *services.Info {
 	return &services.Info{
-		Name:        "dummy",
-		Description: "Description for Dummy service",
-		ParentKeys:  nil,
+		Name:           "dummy",
+		Description:    "Description for Dummy service",
+		ParentServices: nil,
 	}
 }
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/sacloud/services"
 	"github.com/sacloud/services/meta"
+	"github.com/sacloud/services/naming"
 	"github.com/sacloud/services/validate"
 )
 
 // NewParameter 指定のfuncのパラメータを新規作成&初期化して返す
 func NewParameter(service services.Service, funcName string) (interface{}, error) {
-	method, found := reflect.TypeOf(service).MethodByName(funcName)
+	method, found := reflect.TypeOf(service).MethodByName(naming.ToUpperCamelCase(funcName))
 	if !found {
 		return nil, fmt.Errorf("method %q not found", funcName)
 	}
@@ -46,7 +47,7 @@ func ServiceMeta(service services.Service) ([]OperationMeta, error) {
 	ops := service.Operations()
 	var results []OperationMeta
 	for _, op := range ops {
-		fields, err := ParameterMeta(service, op.Name)
+		fields, err := ParameterMeta(service, op.FuncName())
 		if err != nil {
 			return nil, err
 		}

--- a/helper/printer.go
+++ b/helper/printer.go
@@ -33,7 +33,7 @@ func PrintServiceMeta(service services.Service) {
 	fmt.Printf("Name: %s\n", info.Name)
 	fmt.Printf("PkgPath: %s\n", ServicePkgPath(service))
 	fmt.Printf("Description: %s\n", info.Description)
-	fmt.Printf("ParentKeys: %s\n", info.ParentKeys)
+	fmt.Printf("ParentServices: %s\n", info.ParentServices)
 
 	fmt.Println("Operations:")
 	for _, op := range ops {

--- a/naming/naming.go
+++ b/naming/naming.go
@@ -74,11 +74,11 @@ func ToKebabCase(name string) string {
 	return Normalize(xstrings.ToKebabCase(name))
 }
 
-func ToCamelCase(name string) string {
+func ToUpperCamelCase(name string) string {
 	return Normalize(xstrings.ToCamelCase(xstrings.ToSnakeCase(name)))
 }
 
-func ToCamelCaseWithFirstLower(name string) string {
+func ToCamelCase(name string) string {
 	return Normalize(xstrings.FirstRuneToLower(xstrings.ToCamelCase(xstrings.ToSnakeCase(name))))
 }
 

--- a/naming/naming_test.go
+++ b/naming/naming_test.go
@@ -27,7 +27,7 @@ func TestNames(t *testing.T) {
 		out string
 	}{
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "AuthStatus",
 			out: "AuthStatus",
 		},
@@ -37,12 +37,12 @@ func TestNames(t *testing.T) {
 			out: "ipv4",
 		},
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "IPv4",
 			out: "IPv4",
 		},
 		{
-			f:   ToCamelCaseWithFirstLower,
+			f:   ToCamelCase,
 			in:  "IPv4",
 			out: "ipv4",
 		},
@@ -52,27 +52,27 @@ func TestNames(t *testing.T) {
 			out: "dns",
 		},
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "DNS",
 			out: "Dns",
 		},
 		{
-			f:   ToCamelCaseWithFirstLower,
+			f:   ToCamelCase,
 			in:  "DNS",
 			out: "dns",
 		},
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "ipv6-enable",
 			out: "IPv6Enable",
 		},
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "sim-info",
 			out: "SimInfo",
 		},
 		{
-			f:   ToCamelCase,
+			f:   ToUpperCamelCase,
 			in:  "simple-monitor",
 			out: "SimpleMonitor",
 		},

--- a/service.go
+++ b/service.go
@@ -14,7 +14,12 @@
 
 package services
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sacloud/services/naming"
+)
 
 // SupportedOperation サービスが提供する操作のメタデータ
 type SupportedOperation struct {
@@ -23,6 +28,19 @@ type SupportedOperation struct {
 
 	// 操作種別、種別によりIdが必要/不要が決定される
 	OperationType Operations
+}
+
+func (op *SupportedOperation) EqualsByName(name string) bool {
+	return naming.ToKebabCase(name) == naming.ToKebabCase(op.Name)
+}
+
+func (op *SupportedOperation) FuncName() string {
+	return naming.ToUpperCamelCase(op.Name)
+}
+
+// WithContextFuncName Nameを持つFuncに対応する、context.Contextを受け取るFuncの名前を返す
+func (op *SupportedOperation) WithContextFuncName() string {
+	return fmt.Sprintf("%sWithContext", naming.ToUpperCamelCase(op.Name))
 }
 
 // Service 各サービスが実装すべきインターフェース

--- a/service.go
+++ b/service.go
@@ -14,9 +14,11 @@
 
 package services
 
+import "strings"
+
 // SupportedOperation サービスが提供する操作のメタデータ
 type SupportedOperation struct {
-	// 操作(メソッド)の名前
+	// 操作(メソッド)の名前(ケバブケース)
 	Name string
 
 	// 操作種別、種別によりIdが必要/不要が決定される
@@ -38,14 +40,23 @@ type Service interface {
 
 // Info サービスについての情報
 type Info struct {
-	// サービスの名前
+	// サービスの名前(ケバブケース)
 	Name string
 
 	// サービスの説明
 	Description string
 
-	// 親リソースを特定するために必要なフィールドの名前
+	// 親サービスの名称リスト
 	//
-	// 例えばサーバの配下のリソースであれば"ServerId"などが指定される
-	ParentKeys []string
+	// 例えばservice1サービスがservice1/service2/service3という階層構造の場合、
+	// ["service1", "service2"]となる。
+	// この場合、service3サービスの各操作ではService1IdとService2Idというフィールドが存在し、必須パラメータであることが期待される。
+	// (ここで指定した名前をアッパーキャメルケースにしたものがフィールド名になる)
+	ParentServices []string
+}
+
+// FullName 親サービス名まで含めたサービス名称を返す
+func (info *Info) FullName() string {
+	elems := info.ParentServices
+	return strings.Join(append(elems, info.Name), "/")
 }


### PR DESCRIPTION
closes #4 

あらかじめサービスを登録しておき、文字列+mapなどの指定だけで各サービスの操作を呼び出せるDispatcherの仕組みを実装する。

```go
import (
	"fmt"

	"github.com/sacloud/services/dispatcher"
	"github.com/sacloud/services/dummy"
)

func Example() {
	// サービスの登録
	dispatcher.Register("my-platform", dummy.New())

	// サービスの呼び出し(プラットフォーム名 + 対象リソース名 + 操作, パラメータを渡す)
	arguments := []string{"my-platform", "dummy", "read"}
	parameter := map[string]interface{}{"Param1": "example"}

	result, err := dispatcher.Dispatch(arguments, parameter)
	if err != nil {
		panic(err)
	}
	fmt.Println(result.(*dummy.ReadResult).Dummy)
	// output: result
}
```

CLIやプロキシサーバ経由での利用を想定しており、クライアント側はサービスが提供するメタデータをもとにパラメータを組み立て、単一のエンドポイント(services/dispatcher)を呼び出すことでサービスを利用する。

これによりクライアント側からサービスを呼び出す手順が単一となることでクライアント側のコード生成がシンプルになる。