### PR TITLE
パラメータで例示用の値を返す仕組みを導入

### DIFF
--- a/dummy/example.go
+++ b/dummy/example.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dummy
+
+import (
+	"context"
+
+	"github.com/sacloud/services/examples"
+	"github.com/sacloud/services/meta"
+)
+
+func (s *Service) Example(req *ExampleRequest) ([]*ExampleRequest, error) {
+	return s.ExampleWithContext(context.Background(), req)
+}
+
+func (s *Service) ExampleWithContext(ctx context.Context, req *ExampleRequest) ([]*ExampleRequest, error) {
+	return []*ExampleRequest{req}, nil
+}
+
+type ExampleRequest struct {
+	Field1  string
+	Field2  string
+	Options string `meta:",options=example_options"` // example_optionsはなるべく同一ファイル内でoptionDefsに定義する
+}
+
+var exampleOptions = &meta.Option{Key: "example_options", Values: []string{"example1", "example2"}}
+
+func init() {
+	optionDefs = append(optionDefs, exampleOptions)
+}
+
+func (req *ExampleRequest) Examples() interface{} {
+	return &ExampleRequest{
+		Field1:  examples.Id,
+		Field2:  examples.Description,
+		Options: exampleOptions.String(), // オプションを持つ場合、meta.OptionのString()またはexamples.OptionsString()で指定する
+	}
+}

--- a/dummy/find.go
+++ b/dummy/find.go
@@ -16,6 +16,8 @@ package dummy
 
 import (
 	"context"
+
+	"github.com/sacloud/services/meta"
 )
 
 func (s *Service) Find(req *FindRequest) ([]*FindResult, error) {
@@ -33,6 +35,12 @@ func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*Fin
 type FindRequest struct {
 	Field1 string `validate:"required"`
 	Field2 string `validate:"omitempty,option2" meta:",options=option2"`
+}
+
+func init() {
+	optionDefs = append(optionDefs,
+		&meta.Option{Key: "option2", Values: []string{"o3", "o4"}},
+	)
 }
 
 func (req *FindRequest) Initialize() {

--- a/dummy/service.go
+++ b/dummy/service.go
@@ -61,12 +61,13 @@ func (s *Service) Operations() []services.SupportedOperation {
 	}
 }
 
+var optionDefs = []*meta.Option{
+	{Key: "option1", Values: []string{"o1", "o2"}},
+}
+
 func (s *Service) Config() *services.Config {
 	return &services.Config{
-		OptionDefs: []*meta.Option{
-			{Key: "option1", Values: []string{"o1", "o2"}},
-			{Key: "option2", Values: []string{"o3", "o4"}},
-		},
+		OptionDefs: optionDefs,
 	}
 }
 

--- a/examples/examples.go
+++ b/examples/examples.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The sacloud/services Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package examples
+//
+// パラメータの例示のための汎用的な値を提供する
+package examples
+
+import (
+	"strings"
+)
+
+var (
+	Id          = "123456789012"
+	Name        = "example"
+	Description = "example"
+	Tags        = []string{"tag1", "tag2=value"}
+
+	IpAddress        = "192.0.2.11"
+	IpAddresses      = []string{"192.0.2.21", "192.0.2.22"}
+	VirtualIpAddress = "192.0.2.101"
+	NetworkMaskLen   = 24
+	DefaultRoute     = "192.0.2.1"
+
+	MacAddress   = "00:00:5E:00:53:01"
+	MacAddresses = []string{"00:00:5E:00:53:11", "00:00:5E:00:53:12"}
+
+	SlackNotifyWebhooksURL = "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+
+	ScriptContent = `#!/bin/bash
+
+...`
+
+	PublicKeyContent = "ssh-rsa ..."
+
+	FilePath = "/path/to/file"
+)
+
+func OptionsString(opts []string) string {
+	return strings.Join(opts, " | ")
+}

--- a/meta/parser.go
+++ b/meta/parser.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/sacloud/services/naming"
 )
@@ -56,6 +57,10 @@ func (o *Option) GetValues() []string {
 		values = append(values, o.ValuesFn()...)
 	}
 	return values
+}
+
+func (o *Option) String() string {
+	return strings.Join(o.GetValues(), " | ")
 }
 
 // Parser meta-tagのパーサー

--- a/parameter.go
+++ b/parameter.go
@@ -24,3 +24,10 @@ type ParameterInitializer interface {
 type ParameterValidator interface {
 	Validate() error
 }
+
+// ParameterExampleValuer パラメータが値の例示をサポートする場合に実装するインターフェース
+//
+// ここで返される値はJSONまたはYAMLで出力されることがあるため適切なタグを付与しておくこと
+type ParameterExampleValuer interface {
+	Examples() interface{}
+}


### PR DESCRIPTION
closes #22 

各操作のパラメータ向けに以下のインターフェースを追加

```go
// ParameterExampleValuer パラメータが値の例示をサポートする場合に実装するインターフェース
//
// ここで返される値はJSONまたはYAMLで出力されることがあるため適切なタグを付与しておくこと
type ParameterExampleValuer interface {
	Examples() interface{}
}
```